### PR TITLE
I've made some changes to ensure the correct order creation date and …

### DIFF
--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
       .from('integracao_pedidos')
       .insert({
         codigo: pedido.codigo || null,
-        data: pedido.data ? new Date(pedido.data) : new Date(),
+        data: new Date(),
         solicitante: pedido.solicitante,
         observacoes: pedido.observacoes || null
       })

--- a/app/relatorios/page.tsx
+++ b/app/relatorios/page.tsx
@@ -70,8 +70,16 @@ export default function Relatorios() {
       
       const result = await getPedidos(filters);
       
-      setPedidos(result);
-      setFilteredPedidos(result);
+      // Explicitly sort by date descending (newest first)
+      // Ensure 'data' is a string that can be parsed by Date
+      const sortedResult = result.sort((a, b) => {
+        const dateA = new Date(a.data).getTime();
+        const dateB = new Date(b.data).getTime();
+        return dateB - dateA; // For descending order
+      });
+
+      setPedidos(sortedResult);
+      setFilteredPedidos(sortedResult);
     } catch (err) {
       console.error("Erro ao buscar pedidos:", err);
       toast({


### PR DESCRIPTION
…to sort reports by date.

- I modified the POST API endpoint for orders (/api/pedidos) to always use the current server timestamp for the 'data' field upon order creation. This prevents incorrect dates from being saved.
- I updated the reports page (app/relatorios/page.tsx) to explicitly sort orders by their creation date in descending order (newest first) on the client-side. This ensures consistent display even if the API's sort order were to change.

I've confirmed that both changes are working as expected.